### PR TITLE
Update _index.md

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -11,7 +11,6 @@ alwaysopen = false
 
 |種別|日程|内容|
 |----|----|----|
-|リリース|2019/1月上旬|アーケード版のアップデート|
 |リリース|2019/2月中旬|ゲーム調整、ミュージック追加|
 |リリース|2019/3月末|無償追加キャラクター1体追加|
 |リリース|2019/5月末まで|無償追加キャラクター1体、有償追加キャラクター1体追加|
@@ -22,7 +21,6 @@ alwaysopen = false
 
 |種別|日程|場所|内容|
 |----|----|----|----|
-|大会|2019/1/12(土)|東京（新宿）|[クラブセガ新宿西口 シングル大会](https://twitter.com/18goSFEX2plus/status/1082175967022346241)|
 |大会|2019/1/20(日)|大阪（茨木）|[ゲームディーノ 『FIGHTING EX LAYER』シングル大会](http://blog.livedoor.jp/game_dino/archives/54716938.html)|
 |大会|2019/2/9(土)|東京|[STRONG STYLE JAPAN コミュニティイベント](https://strongstylejp.walker-gaming.net/event.html)|
 |大会|2019/2/15(金)～17(日)|福岡|[Evo Japan 2019 サイドトーナメント](https://www.evojapan.net/2019/)|
@@ -58,9 +56,11 @@ alwaysopen = false
 
 |日程|場所|内容|結果|動画|
 |----|----|----|----|----|
+|2019/1/14(月)|新潟|[ゲームセンターテクノポリス ファイティングEXレイヤースペシャル大会](https://twitter.com/GC_Tecnopolis/status/1084334036426711041)|-|-|
+|2019/1/12(土)|東京（新宿）|[クラブセガ新宿西口 シングル大会](https://twitter.com/18goSFEX2plus/status/1082175967022346241)|[Twitter](https://twitter.com/BA_shinjuku/status/1084782529775718403)|[YouTube](https://www.youtube.com/watch?v=88Jk9hGw1Ew&feature=youtu.be&a=)|
 |2019/1/3(木)|東京（中野）|[中野TRF 年明けSPレベル分け交流２on２大会](http://trftrf.com/event.html#0103)|-|-|
-|2018/12/30(日)|埼玉（南浦和）|[プレイスポットビッグワン2nd『FIGHTING EX LAYERシングル大会』](https://twitter.com/public_bigone/status/1078508328202825728)|[twitter](https://twitter.com/18goSFEX2plus/status/1079323340022530048)|-|
-|2018/12/15(土)|福岡（七隈）|[G-stage七隈 ファイティングEXレイヤー大会](https://twitter.com/Gstage_Nanakuma/status/1065526587485868032)|[twitter](https://twitter.com/Gstage_Nanakuma/status/1073834139479027712)|-|
+|2018/12/30(日)|埼玉（南浦和）|[プレイスポットビッグワン2nd『FIGHTING EX LAYERシングル大会』](https://twitter.com/public_bigone/status/1078508328202825728)|[Twitter](https://twitter.com/18goSFEX2plus/status/1079323340022530048)|-|
+|2018/12/15(土)|福岡（七隈）|[G-stage七隈 ファイティングEXレイヤー大会](https://twitter.com/Gstage_Nanakuma/status/1065526587485868032)|[Twitter](https://twitter.com/Gstage_Nanakuma/status/1073834139479027712)|-|
 |2018/12/09(日)|宮城（仙台）|[プレイランドエフワンR ファイティングEXレイヤー大会](https://twitter.com/PLAYLANDF1R/status/1070610099398295552)|-|-|
 |2018/12/06(木)|東京（中野）|[中野TRF シングル無差別級大会](http://trftrf.com/event.html#Thurs)|-|-|
 |2018/12/04(火)|東京（高田馬場）|[ゲーセンミカド ストリートファイターカーニバル（SFC）12](http://sp.ch.nicovideo.jp/mikadogame/blomaga/ar1699549) ※イベントの1種目|[Twitter](https://twitter.com/18goSFEX2plus/status/1069943609456095232)|[YouTube](https://www.youtube.com/watch?v=Q9mmirvJM1Y)|


### PR DESCRIPTION
1月のアーケードアップデート削除、西新宿セガシングル大会を過去のイベントに移動（結果、動画追加）、ゲームセンターテクノポリスを過去のイベントに追加、Twitter表記を頭文字を大文字に統一。よろしくですー